### PR TITLE
Update productmetadata value to use interface

### DIFF
--- a/Products.go
+++ b/Products.go
@@ -123,9 +123,9 @@ type ProductAttribute struct {
 }
 
 type ProductMetaData struct {
-	Id    int64  `json:"id"`
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Id    int64       `json:"id"`
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
 }
 
 type ProductMetaDataJSON struct {


### PR DESCRIPTION
The value of the WooCommerce metadata sometimes requires an array. To allow the metadata to accept array as value the type interface{} is used instead of string.